### PR TITLE
Register Allurement config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/allurement/core/Allurement.java
+++ b/src/main/java/com/minecraftabnormals/allurement/core/Allurement.java
@@ -3,6 +3,7 @@ package com.minecraftabnormals.allurement.core;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.DataProcessors;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedData;
 import com.minecraftabnormals.abnormals_core.common.world.storage.tracking.TrackedDataManager;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.allurement.core.data.EnchantmentTagGenerator;
 import com.minecraftabnormals.allurement.core.data.LootModifierGenerator;
@@ -42,6 +43,7 @@ public class Allurement {
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, AllurementConfig.COMMON_SPEC);
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, AllurementConfig.CLIENT_SPEC);
+		DataUtil.registerConfigCondition(Allurement.MOD_ID, AllurementConfig.COMMON, AllurementConfig.CLIENT);
 	}
 
 	private void dataSetup(GatherDataEvent event) {

--- a/src/main/java/com/minecraftabnormals/allurement/core/AllurementConfig.java
+++ b/src/main/java/com/minecraftabnormals/allurement/core/AllurementConfig.java
@@ -2,6 +2,7 @@ package com.minecraftabnormals.allurement.core;
 
 
 import com.google.common.collect.Lists;
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -13,38 +14,81 @@ import java.util.List;
 public class AllurementConfig {
 
 	public static class Common {
+
+		@ConfigKey("horse_armor_is_enchantable")
 		public final ConfigValue<Boolean> enchantableHorseArmor;
+
+		@ConfigKey("enchanted_horse_armor_generates")
 		public final ConfigValue<Boolean> enchantedHorseArmorGenerates;
+
+		@ConfigKey("unenchanted_horse_armor_loot_tables")
 		public final ConfigValue<List<String>> unenchantedHorseArmorLootTables;
 
+		@ConfigKey("riptide_works_in_cauldrons")
 		public final ConfigValue<Boolean> riptideWorksInCauldrons;
 
+
+		@ConfigKey("soul_speed_increases_damage")
 		public final ConfigValue<Boolean> soulSpeedHurtsMore;
+
+		@ConfigKey("soul_speed_damage_factor")
 		public final ConfigValue<Float> soulSpeedDamageFactor;
 
+
+		@ConfigKey("infinity_requires_arrows")
 		public final ConfigValue<Boolean> infinityRequiresArrows;
 
+
+		@ConfigKey("protection_disabled")
 		public final ConfigValue<Boolean> disableProtection;
 
+
+		@ConfigKey("alleviating_enabled")
 		public final ConfigValue<Boolean> enableAlleviating;
+
+		@ConfigKey("alleviating_healing_factor")
 		public final ConfigValue<Float> alleviatingHealingFactor;
 
+
+		@ConfigKey("launch_enabled")
 		public final ConfigValue<Boolean> enableLaunch;
+
+		@ConfigKey("launch_vertical_factor")
 		public final ConfigValue<Double> launchVerticalFactor;
 
+
+		@ConfigKey("reeling_enabled")
 		public final ConfigValue<Boolean> enableReeling;
+
+		@ConfigKey("reeling_horizontal_factor")
 		public final ConfigValue<Double> reelingHorizontalFactor;
+
+		@ConfigKey("reeling_vertical_factor")
 		public final ConfigValue<Double> reelingVerticalFactor;
 
+
+		@ConfigKey("reforming_enabled")
 		public final ConfigValue<Boolean> enableReforming;
+
+		@ConfigKey("reforming_tick_rate")
 		public final ConfigValue<Integer> reformingTickRate;
 
+
+		@ConfigKey("shockwave_enabled")
 		public final ConfigValue<Boolean> enableShockwave;
 
+
+		@ConfigKey("vengeance_enabled")
 		public final ConfigValue<Boolean> enableVengeance;
+
+		@ConfigKey("vengeance_damage_factor")
 		public final ConfigValue<Float> vengeanceDamageFactor;
 
+
+		@ConfigKey("level_scaling_removed")
 		public final ConfigValue<Boolean> removeLevelScaling;
+
+		@ConfigKey("experience_per_level")
 		public final ConfigValue<Integer> experiencePerLevel;
 
 		Common(ForgeConfigSpec.Builder builder) {
@@ -116,7 +160,11 @@ public class AllurementConfig {
 	}
 
 	public static class Client {
+
+		@ConfigKey("infinity_arrow_texture_enabled")
 		public final ConfigValue<Boolean> infinityArrowTexture;
+
+		@ConfigKey("infinity_arrow_glint_enabled")
 		public final ConfigValue<Boolean> infinityArrowGlint;
 
 		Client(ForgeConfigSpec.Builder builder) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.